### PR TITLE
Changes to Item Selection + Additional nodes for historical merge for multiple sensors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
       "openware-data-aggregate": "./dist/nodes/openware-data-aggregate/openware-data-aggregate.js",
       "openware-csv2ow": "./dist/nodes/openware-csv2ow/openware-csv2ow.js",
       "openware-stream-send": "./dist/nodes/openware-stream-send/openware-stream-send.js",
-      "openware-item-select": "./dist/nodes/openware-item-select/openware-item-select.js"
+      "openware-item-select": "./dist/nodes/openware-item-select/openware-item-select.js",
+      "openware-item-multiple-select": "./dist/nodes/openware-item-multiple-select/openware-item-multiple-select.js",
+      "openware-data-historical-merge": "./dist/nodes/openware-data-historical-merge/openware-data-historical-merge.js"
     }
   },
   "dependencies": {

--- a/src/nodes/openware-data-historical-merge/modules/types.ts
+++ b/src/nodes/openware-data-historical-merge/modules/types.ts
@@ -1,0 +1,7 @@
+import { Node, NodeDef } from "node-red";
+import { OpenwareDataHistoricalMergeOptions } from "../shared/types";
+
+export interface OpenwareDataHistoricalMergeNodeDef extends NodeDef, OpenwareDataHistoricalMergeOptions {}
+
+// export interface OpenwareDataHistoricalMergeNode extends Node {}
+export type OpenwareDataHistoricalMergeNode = Node;

--- a/src/nodes/openware-data-historical-merge/openware-data-historical-merge.html/editor.html
+++ b/src/nodes/openware-data-historical-merge/openware-data-historical-merge.html/editor.html
@@ -1,0 +1,18 @@
+<script type="text/html" data-template-name="openware-data-historical-merge">
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+</div>
+<div class="form-row">
+    <label for="node-input-server"><i class="fa fa-tag"></i> Server</label>
+    <input type="text" id="node-input-server" placeholder="Server...">
+</div>
+<div class="form-row">
+    <label for="node-input-output"><i class="fa fa-file"></i> Output</label>
+    <input type="text" id="node-input-output" placeholder="JSON">
+</div>
+<div class="form-row" id="node-input-delimiter-row">
+    <label for="node-input-delimiter"><i class="fa fa-file"></i> Delimiter</label>
+    <input type="text" id="node-input-delimiter" placeholder=",">
+</div>
+</script>

--- a/src/nodes/openware-data-historical-merge/openware-data-historical-merge.html/help.html
+++ b/src/nodes/openware-data-historical-merge/openware-data-historical-merge.html/help.html
@@ -1,0 +1,37 @@
+<script type="text/html" data-help-name="openware-data-historical-merge">
+  <h1>OpenWARE Historical Merge Node</h1>
+
+  <h2>Introduction</h2>
+  <p>The OpenWARE Historical Merge node merges and synchronizes sensor data from multiple sensors in a given time span.</p>
+
+  <h2>Node Configuration</h2>
+  <ul>
+    <li><strong>Server:</strong> <br> The open.WARE server configuration from which to fetch the items. This should be configured to connect to your open.WARE instance.</li>
+    <li><strong>Output Format:</strong> Specifies the format for output data (JSON, VALUES_ONLY, CSV).</li>
+    <li><strong>Delimiter:</strong> (For CSV output) The delimiter to use for CSV formatting.</li>
+  </ul>
+
+  <h2>Input</h2>
+    <p>The node expects input messages containing parameters for merging sensor data on openWARE:</p>
+  <ul>
+      <li><strong>sensorInfos:</strong> An array of sensor information consisting of <code>source</code>, <code>sensor</code>(id) and <code>dimension</code></li>
+      <li><strong>start:</strong> The start date/time of the historical time span.</li>
+      <li><strong>end:</strong> The end date/time of the historical time span.</li>
+      <li><strong>pipe:</strong> (Optional) Custom data pipeline sent to openWARE (Expert function: Leads to a complete overwrite of the merge operation)</li>
+  </ul>
+
+  <h2>Output</h2>
+  <p>The node sends historical data in the specified format:</p>
+  <ul>
+      <li><strong>JSON:</strong> Output data in JSON format.</li>
+      <li><strong>VALUES_ONLY:</strong> Output only the values of aggregated data along with value types.</li>
+      <li><strong>CSV:</strong> Output data in CSV format.</li>
+  </ul>
+
+  <h2>Usage</h2>
+  <ol>
+      <li><strong>Input Parameters:</strong> Provide input parameters for data aggregation.</li>
+      <li><strong>Data Collection:</strong> The node collects the data from the specified sources within the defined time interval and merges them to a time synchronized data array in the <a href="https://docs.openinc.dev/docs/openware/BasicDataFormat">data format</a>.</li>
+      <li><strong>Output:</strong> Receive the aggregated data in the specified format.</li>
+  </ol>
+</script>

--- a/src/nodes/openware-data-historical-merge/openware-data-historical-merge.html/index.ts
+++ b/src/nodes/openware-data-historical-merge/openware-data-historical-merge.html/index.ts
@@ -1,0 +1,52 @@
+import { EditorRED } from "node-red";
+import { OpenwareDataHistoricalMergeEditorNodeProperties } from "./modules/types";
+
+declare const RED: EditorRED;
+
+RED.nodes.registerType<OpenwareDataHistoricalMergeEditorNodeProperties>("openware-data-historical-merge", {
+  category: "openWARE",
+  color: "#a6bbcf",
+  defaults: {
+    name: { value: "openware-data-historical-merge", type: "text" },
+    server: { value: "", type: "openware-config" },
+    output: { value: "JSON", type: "text" },
+    delimiter: { value: ",", type: "text" },
+  },
+  inputs: 1,
+  outputs: 1,
+  icon: "file.png",
+  paletteLabel: "openware data historical merge",
+  label: function () {
+    return this.name || "openware data historical merge";
+  },
+  oneditprepare: function () {
+    $("#node-input-output").typedInput({
+      types: [
+        {
+          value: "JSON",
+
+          options: [
+            { value: "JSON", label: "JSON" },
+            { value: "CSV", label: "CSV" },
+            { value: "VALUES_ONLY", label: "JSON(only values)" },
+          ],
+        },
+      ],
+    });
+    $("#node-input-output").change(function () {
+      console.log("Changed", $("#node-input-output").val());
+      const element = $("#node-input-delimiter").parent();
+      if ($("#node-input-output").val() === "CSV") {
+        console.log("CSV");
+        if (element.show) {
+          element.show();
+        }
+      } else {
+        console.log("JSON");
+        if (element.hide) {
+          element.hide();
+        }
+      }
+    });
+  },
+});

--- a/src/nodes/openware-data-historical-merge/openware-data-historical-merge.html/modules/types.ts
+++ b/src/nodes/openware-data-historical-merge/openware-data-historical-merge.html/modules/types.ts
@@ -1,0 +1,6 @@
+import { EditorNodeProperties } from "node-red";
+import { OpenwareDataHistoricalMergeOptions } from "../../shared/types";
+
+export interface OpenwareDataHistoricalMergeEditorNodeProperties
+  extends EditorNodeProperties,
+    OpenwareDataHistoricalMergeOptions {}

--- a/src/nodes/openware-data-historical-merge/openware-data-historical-merge.ts
+++ b/src/nodes/openware-data-historical-merge/openware-data-historical-merge.ts
@@ -1,0 +1,128 @@
+import { NodeInitializer } from "node-red";
+import { OpenwareDataHistoricalMergeNode, OpenwareDataHistoricalMergeNodeDef } from "./modules/types";
+import { ConfigNode } from "../shared/types";
+import { HistoricMergePayloadType, PipePayloadType } from "./shared/types";
+
+const nodeInit: NodeInitializer = (RED): void => {
+  function OpenwareDataHistoricalMergeNodeConstructor(
+    this: OpenwareDataHistoricalMergeNode,
+    config: OpenwareDataHistoricalMergeNodeDef
+  ): void {
+    const server = RED.nodes.getNode(config.server) as ConfigNode;
+    RED.nodes.createNode(this, config);
+    const node = this;
+
+    this.on("input", async function (msg, send, done) {
+      console.log("Historical Merge Node: ", msg);
+      if (!server || !server.credentials.session) {
+        node.status({
+          fill: "red",
+          shape: "dot",
+          text: "Select a open.WARE Server and sign in.",
+        });
+        return;
+      }
+
+      if (
+        ((<HistoricMergePayloadType>msg.payload).sensorInfos &&
+          (<HistoricMergePayloadType>msg.payload).start &&
+          (<HistoricMergePayloadType>msg.payload).end) ||
+        (<PipePayloadType>msg.payload).pipe
+      ) {
+        //@ts-expect-error
+        const pipe = msg.payload.pipe || {
+          stages: [
+            {
+              action: "sync_merge",
+              params: {
+                items: 
+                  (<HistoricMergePayloadType>msg.payload).sensorInfos.map((info) => {
+                    return {
+                      stages: [
+                        {
+                          action: "historical",
+                          params: {
+                            source: info.source,
+                            id: info.sensor,
+                            start: (<HistoricMergePayloadType>msg.payload).start,
+                            end: (<HistoricMergePayloadType>msg.payload).end,
+                          }
+                        },
+                        {
+                          action: "dimension_reduce",
+                          params: {
+                            dimension: info.dimension
+                          }
+                        }
+                      ]
+                    }
+                  }),
+              },
+            },
+          ],
+        };
+        console.log("Pipe: ", JSON.stringify(pipe, null, 2));
+        node.status({ fill: "blue", shape: "dot", text: "Fetching data..." });
+        const data = await server.api.pipe(pipe);
+        console.log(JSON.stringify(data, null, 2));
+
+        if (data.status !== "success") {
+          node.status({
+            fill: "red",
+            shape: "dot",
+            text: "Error fetching data." + data.payload.error,
+          });
+          node.error(data);
+          return;
+        }
+        node.status({});
+        if (config.output === "JSON") {
+          node.send(data);
+          return;
+        }
+        if (config.output === "VALUES_ONLY") {
+          node.send({
+            payload: data.item.values,
+            //@ts-expect-error
+            valueTypes: data.item.valueTypes,
+            request: msg.payload,
+          });
+          return;
+        }
+        if (config.output === "CSV") {
+          const csvData = data.item.values.map(
+            (v) =>
+              `${v.date},${v.value
+                .map((v, index) =>
+                  data.item.valueTypes[index].type === "String" ? `"${v}"` : v
+                )
+                .join(config.delimiter)}`
+          );
+
+          csvData.unshift(
+            ["date", ...data.item.valueTypes.map((v) => v.name)].join(
+              config.delimiter
+            )
+          );
+
+          node.send(Object.assign(data, { payload: csvData.join("\n") }));
+          return;
+        }
+        send(msg);
+        done();
+      } else {
+        node.status({
+          fill: "red",
+          shape: "dot",
+          text: "Missing required parameters.",
+        });
+        console.log("Missing required parameters.");
+        console.log(msg.payload);
+      }
+    });
+  }
+
+  RED.nodes.registerType("openware-data-historical-merge", OpenwareDataHistoricalMergeNodeConstructor);
+};
+
+export = nodeInit;

--- a/src/nodes/openware-data-historical-merge/shared/types.ts
+++ b/src/nodes/openware-data-historical-merge/shared/types.ts
@@ -1,0 +1,18 @@
+export interface OpenwareDataHistoricalMergeOptions {
+  server: string;
+  output: "JSON" | "VALUES_ONLY" | "CSV";
+  delimiter?: string;
+}
+
+export type PipePayloadType = {
+  pipe: any;
+};
+export type HistoricMergePayloadType = {
+  sensorInfos: {
+    source: string;
+    sensor: string;
+    dimension: number;
+  }[];
+  start: number;
+  end: number;
+};

--- a/src/nodes/openware-item-multiple-select/modules/types.ts
+++ b/src/nodes/openware-item-multiple-select/modules/types.ts
@@ -1,0 +1,7 @@
+import { Node, NodeDef } from "node-red";
+import { OpenwareItemMultipleSelectOptions } from "../shared/types";
+
+export interface OpenwareItemMultipleSelectNodeDef extends NodeDef, OpenwareItemMultipleSelectOptions {}
+
+// export interface OpenwareItemMultipleSelectNode extends Node {}
+export type OpenwareItemMultipleSelectNode = Node;

--- a/src/nodes/openware-item-multiple-select/openware-item-multiple-select.html/editor.html
+++ b/src/nodes/openware-item-multiple-select/openware-item-multiple-select.html/editor.html
@@ -1,0 +1,37 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.17.0/cdn/themes/light.css" />
+<script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.17.0/cdn/shoelace-autoloader.js"></script>
+
+<script type="text/html" data-template-name="openware-item-multiple-select">
+  <div class="form-row">
+
+    <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+</div>
+  <div class="form-row">
+    <label for="node-input-server"><i class="fa fa-tag"></i> Server</label>
+    <input type="text" id="node-input-server" placeholder="Server...">
+  </div>
+  <div class="form-row">
+    <label for="node-input-items">Item</label>
+    <!-- <sl-select id="node-input-items" multiple clearable> -->
+      <sl-select id="node-input-items" style="width:70%; display: inline-block;" multiple clearable> 
+      <!-- <sl-option value="option-1">Option 1</sl-option> -->
+    </sl-select>
+  </div>
+  <div class="form-row">
+    <label for="node-input-dims">Dimension</label>
+    <!-- <sl-select id="node-input-items" multiple clearable> -->
+      <sl-select id="node-input-dims" style="width:70%; display: inline-block;" multiple clearable> 
+      <!-- <sl-option value="option-1">Option 1</sl-option> -->
+    </sl-select>
+  </div>
+  <div class="form-row">
+    <label for="node-input-start"><i class="icon-clock"></i> Start</label>
+    <input type="datetime-local" id="node-input-start" placeholder="Start">
+  </div>
+  <div class="form-row">
+     <label for="node-input-end"><i class="icon-clock"></i> End</label>
+    <input type="datetime-local" id="node-input-end" placeholder="End">
+  </div>
+</script>

--- a/src/nodes/openware-item-multiple-select/openware-item-multiple-select.html/help.html
+++ b/src/nodes/openware-item-multiple-select/openware-item-multiple-select.html/help.html
@@ -1,0 +1,33 @@
+<script type="text/html" data-help-name="openware-item-multiple-select">
+  <h1>openWARE Item Select Node</h1>
+  <p>The node allows to define a data request object that can be passed to an openWARE historical merge data node.</p>
+
+  <h2>Node Configuration</h2>
+  <ul>
+    <li><strong>Name:</strong> <br> The name of the node instance. This name is used to label the node within your flow.</li>
+    <li><strong>Server:</strong> <br> The open.WARE server configuration from which to fetch the items. This should be configured to connect to your open.WARE instance.<strong>When first configuring or selecting, save the node config once before entering Item and Dimension information.</strong> Otherwise the Item and Dimension dropdown menus are empty.</li>
+    <li><strong>Item:</strong>The sensor item that is to be requested. <strong>If the dropdown is empty</strong> save&close and reopen the configuration after selecting the server.</li>
+    <li><strong>Dimension:</strong>The dimension of the server, that is to be pulled.</li>
+    <li><strong>Start:</strong>The start date/time of the desired time interval.</li>
+    <li><strong>End:</strong>The end date/time of the desired time interval.</li>
+  </ul>
+
+  <h2>Input</h2>
+  <p>The node only needs a trigger (e.g. by an inject node)</p>
+
+  <h2>Output</h2>
+  <p>The node sends the information in the following forward, which is expected by the openWARE historical node:</p>
+  <ul>
+    <li><strong>sourceInfo:</strong> An array of sensor information consisting of <code>source</code>, <code>sensor</code>(id) and <code>dimension</code></li>
+    <li><strong>start:</strong> The start date/time for the data aggregation.</li>
+    <li><strong>end:</strong> The end date/time for the data aggregation.</li>
+  </ul>
+
+  <h2>Usage</h2>
+  <ol>
+    <li><strong>Configure the node:</strong> Specify the server, item, dimension, start and end date/time.</li>
+    <li><strong>Connect:</strong>Connect the output of the node to an openWARE historical merge node.</li>
+    <li><strong>Trigger the node:</strong> Send a message to the node to trigger the data request.</li>
+    <li><strong>Output:</strong> The node sends the data request to the openWARE historical merge node.</li>
+  </ol>
+</script>

--- a/src/nodes/openware-item-multiple-select/openware-item-multiple-select.html/index.ts
+++ b/src/nodes/openware-item-multiple-select/openware-item-multiple-select.html/index.ts
@@ -1,0 +1,121 @@
+import { EditorRED } from "node-red";
+import { OpenwareItemMultipleSelectEditorNodeProperties } from "./modules/types";
+import { OWItemType, ValueType } from "../../shared/types";
+
+declare const RED: EditorRED;
+
+RED.nodes.registerType<OpenwareItemMultipleSelectEditorNodeProperties>("openware-item-multiple-select", {
+  category: "openWARE",
+  color: "#a6bbcf",
+  defaults: {
+    name: { value: "" },
+    server: { value: "", type: "openware-config" },
+    items: { value: [] },
+    dims: { value: [] },
+    start: { value: "" },
+    end: { value: "" },
+  },
+  inputs: 1,
+  outputs: 1,
+  icon: "file.png",
+  paletteLabel: "openware item multiple select",
+  label: function () {
+    return this.name || "openware item multiple select";
+  },
+  oneditprepare: async function () {
+    const itemsSelect = document.getElementById("node-input-items");
+    const cItemValues = this.items.map((el) => el.split("---"));
+    const dimSelect = document.getElementById("node-input-dims");
+
+    const setDimSelectFromSelectedItems = (selectedItems: OWItemType[], setValue: boolean) => {
+      let dimSelectHTML = "";
+      let valueTypes = <ValueType[]>[];
+      for (let item of selectedItems) {
+        dimSelectHTML += "\n<sl-divider></sl-divider>";
+        dimSelectHTML += `<small>${item.source} - ${item.id}</small>`;
+        valueTypes = item.valueTypes;
+        dimSelectHTML += valueTypes
+          .map((dim, index) => {
+            return `<sl-option value="${item.source}---${item.id}---${index}">${dim.name}</sl-option>`;
+          })
+          .join("\n");
+      }
+      dimSelect!.innerHTML = dimSelectHTML;
+
+      if (setValue) {
+        dimSelect!["value"] = this.dims;
+      }
+    }
+
+    const fetchItemAndDims = async () => {
+      const itemsReq = await fetch(`/openware/itemselect/${this.server}`);
+      const items = (await itemsReq.json()) as OWItemType[];
+
+      if (itemsSelect && cItemValues.length > 0) {
+        itemsSelect["value"] = cItemValues.map((el) => el.join("---") as string);
+
+        if (dimSelect) {
+          dimSelect["value"] = this.dims;
+
+          const selected = items.filter(
+            (item) => {
+              for (let id of cItemValues) {
+                if (item.id === id[1] && item.source === id[0]) {
+                  return true;
+                }
+              }
+              return false;
+            }
+          );
+
+          if (selected.length > 0) {
+            setDimSelectFromSelectedItems(selected, true);
+          }
+        }
+      }
+      itemsSelect!.innerHTML = items
+        .sort((a, b) => (a.source + a.name + a.id).localeCompare(b.source + b.name + b.id))
+        .map((item) => {
+          return `<sl-option value="${item.source}---${item.id}">[${item.source}] ${item.name} - ${item.id}</sl-option>`;
+        })
+        .join("\n");
+
+      itemsSelect?.addEventListener("sl-change", (event) => {
+        // @ts-expect-error
+        const value = event?.target.value;
+        let values = []
+        if (value instanceof Array) {
+          values = value;
+        } else {
+          values = [(value || "")];
+        }
+        const sourceIds = values.map((val: string) => val.split("---"));
+
+        const selected = items.filter(
+          (item) => {
+            for (let id of sourceIds) {
+              if (item.id === id[1] && item.source === id[0]) {
+                return true;
+              }
+            }
+            return false;
+          }
+        );
+
+        if (selected.length > 0) {
+          setDimSelectFromSelectedItems(selected, false);
+        }
+      });
+    }
+
+    if (this.server !== "") {
+      fetchItemAndDims()
+    }
+
+    const serverSelect = document.getElementById("node-input-server");
+    serverSelect?.addEventListener("change", async (event) => {
+      this.server = event.target["value"];
+      fetchItemAndDims();
+    });
+  },
+});

--- a/src/nodes/openware-item-multiple-select/openware-item-multiple-select.html/modules/types.ts
+++ b/src/nodes/openware-item-multiple-select/openware-item-multiple-select.html/modules/types.ts
@@ -1,0 +1,6 @@
+import { EditorNodeProperties } from "node-red";
+import { OpenwareItemMultipleSelectOptions } from "../../shared/types";
+
+export interface OpenwareItemMultipleSelectEditorNodeProperties
+  extends EditorNodeProperties,
+    OpenwareItemMultipleSelectOptions {}

--- a/src/nodes/openware-item-multiple-select/openware-item-multiple-select.ts
+++ b/src/nodes/openware-item-multiple-select/openware-item-multiple-select.ts
@@ -1,0 +1,51 @@
+import { NodeInitializer } from "node-red";
+import { OpenwareItemMultipleSelectNode, OpenwareItemMultipleSelectNodeDef } from "./modules/types";
+
+const nodeInit: NodeInitializer = (RED): void => {
+  function OpenwareItemMultipleSelectNodeConstructor(
+    this: OpenwareItemMultipleSelectNode,
+    config: OpenwareItemMultipleSelectNodeDef
+  ): void {
+    RED.nodes.createNode(this, config);
+
+    this.on("input", (msg: any, send, done) => {
+      const items = config.items.length > 0 ? config.items.map(el => el.split("---")) : [];
+      const dims = config.dims.length > 0 ? config.dims : [];
+
+      const sensorInfos = dims.map((dim) => {
+        const dimInfo = dim.split("---");
+        if (dimInfo.length !== 3) {
+          RED.log.error("Invalid dimension configuration");
+          this.debug("Invalid dimension configuration");
+          return;
+        }
+
+        return {
+          source: dimInfo[0],
+          sensor: dimInfo[1],
+          dimension: dimInfo[2],
+        };
+      })
+      for (const item of items) {
+        if (item.length !== 2) {
+          RED.log.error("Invalid item configuration");
+          this.debug("Invalid item configuration");
+          return;
+        }
+      }
+      if (!msg.payload || typeof msg.payload !== "object") {
+        msg.payload = {} as any;
+      }
+      msg.payload.sensorInfos = msg.payload.sensorInfos ?? sensorInfos;
+      msg.payload.start = msg.payload.start ?? new Date(config.start).getTime();
+      msg.payload.end = msg.payload.end ?? new Date(config.end).getTime();
+
+      send(msg);
+      done();
+    });
+  }
+
+  RED.nodes.registerType("openware-item-multiple-select", OpenwareItemMultipleSelectNodeConstructor);
+};
+
+export = nodeInit;

--- a/src/nodes/openware-item-multiple-select/shared/types.ts
+++ b/src/nodes/openware-item-multiple-select/shared/types.ts
@@ -1,0 +1,7 @@
+export interface OpenwareItemMultipleSelectOptions {
+  server: string;
+  items: string[];
+  dims: string[];
+  start: string;
+  end: string;
+}

--- a/src/nodes/openware-item-select/openware-item-select.html/help.html
+++ b/src/nodes/openware-item-select/openware-item-select.html/help.html
@@ -1,3 +1,34 @@
 <script type="text/html" data-help-name="openware-item-select">
-  <p>Node description goes here.</p>
+  <h1>openWARE Item Select Node</h1>
+  <p>The node allows to define a data request object that can be passed to an openWARE historical data node.</p>
+
+  <h2>Node Configuration</h2>
+  <ul>
+    <li><strong>Name:</strong> <br> The name of the node instance. This name is used to label the node within your flow.</li>
+    <li><strong>Server:</strong> <br> The open.WARE server configuration from which to fetch the items. This should be configured to connect to your open.WARE instance.<strong>When first configuring or selecting, save the node config once before entering Item and Dimension information.</strong> Otherwise the Item and Dimension dropdown menus are empty.</li>
+    <li><strong>Item:</strong>The sensor item that is to be requested. <strong>If the dropdown is empty</strong> save&close and reopen the configuration after selecting the server.</li>
+    <li><strong>Dimension:</strong>The dimension of the server, that is to be pulled.</li>
+    <li><strong>Start:</strong>The start date/time of the desired time interval.</li>
+    <li><strong>End:</strong>The end date/time of the desired time interval.</li>
+  </ul>
+
+  <h2>Input</h2>
+  <p>The node only needs a trigger (e.g. by an inject node)</p>
+
+  <h2>Output</h2>
+  <p>The node sends the information in the following forward, which is expected by the openWARE historical node:</p>
+  <ul>
+    <li><strong>source:</strong> The source of the data.</li>
+    <li><strong>sensor:</strong> The sensor ID.</li>
+    <li><strong>start:</strong> The start date/time for the data aggregation.</li>
+    <li><strong>end:</strong> The end date/time for the data aggregation.</li>
+  </ul>
+
+  <h2>Usage</h2>
+  <ol>
+    <li><strong>Configure the node:</strong> Specify the server, item, dimension, start and end date/time.</li>
+    <li><strong>Connect:</strong>Connect the output of the node to an openWARE historical node.</li>
+    <li><strong>Trigger the node:</strong> Send a message to the node to trigger the data request.</li>
+    <li><strong>Output:</strong> The node sends the data request to the openWARE historical node.</li>
+  </ol>
 </script>

--- a/src/nodes/openware-item-select/openware-item-select.html/index.ts
+++ b/src/nodes/openware-item-select/openware-item-select.html/index.ts
@@ -53,7 +53,7 @@ RED.nodes.registerType<OpenwareItemSelectEditorNodeProperties>(
       itemsSelect!.innerHTML = items
         .sort((a, b) => (a.source + a.name).localeCompare(b.source + b.name))
         .map((item) => {
-          return `<sl-option value="${item.source}---${item.id}">[${item.source}] ${item.name}</sl-option>`;
+          return `<sl-option value="${item.source}---${item.id}">[${item.source}] ${item.name} - ${item.id}</sl-option>`;
         })
         .join("\n");
 

--- a/src/nodes/openware-items/openware-items.ts
+++ b/src/nodes/openware-items/openware-items.ts
@@ -2,7 +2,7 @@ import { NodeInitializer } from "node-red";
 import { OpenwareItemsNode, OpenwareItemsNodeDef } from "./modules/types";
 import { ConfigNode, ItemMessage, OWItemType } from "../shared/types";
 import { ItemsMsgType } from "./shared/types";
-import { isError } from "../shared/Helper";
+import { isError } from "../shared/helper";
 
 const nodeInit: NodeInitializer = (RED): void => {
   function OpenwareItemsNodeConstructor(

--- a/src/nodes/shared/types.ts
+++ b/src/nodes/shared/types.ts
@@ -3,7 +3,7 @@ import { ChildProcessWithoutNullStreams } from "node:child_process";
 import { Node, NodeDef } from "node-red";
 export type ProcessChild = ChildProcessWithoutNullStreams | undefined | null;
 export type ValueType = {
-  type: "number" | "string" | "boolean" | "geo" | "object";
+  type: "number" | "string" | "boolean" | "geo" | "object" | "String" | "Boolean" | "Number" | "Geo" | "Object";
   name: string;
   unit: string;
 };
@@ -42,11 +42,7 @@ export type OWItemType = {
     date: number;
     value: any[];
   }[];
-  valueTypes: {
-    name: string;
-    type: "String" | "Boolean" | "Number" | "Geo" | "Object";
-    unit: string;
-  }[];
+  valueTypes: ValueType[];
 };
 
 export type ConfigNode = Node & {


### PR DESCRIPTION
- small changes to item-select
- - Fix for item list not loading when just entered server info
- - Removed double code for filling in the dropdowns

- Added node for multi item select 
- - Similar to item-select node, but the dropdowns allow multiple sensors and dimensions to be selected
- - Output format is fitting to new historical-merge node
- Added historical merge node
- - Replaces the workaround to use the aggregate node with overwritten pipe, which is hard to document and explain to non-pro users
- Added missing documentation HTML